### PR TITLE
Remove explicit reference to aws provider

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -1,4 +1,0 @@
-provider "aws" {
-  version = "~> 1.3"
-  region  = "${var.region}"
-}


### PR DESCRIPTION
I was getting this error when trying to remove a reference to this module in the truss-infra repo:
```
module.pivotal_tracker_bot_prod.aws_api_gateway_deployment.slack_pivotal_tracker_bot_api_deployment:
configuration for module.pivotal_tracker_bot_prod.provider.aws is not present; a provider configuration block is required for all operations
```

Apparently, we should not define providers inside of modules and instead rely on the provider in the root Terraform configuration. [Context](https://github.com/hashicorp/terraform/issues/17928#issuecomment-384311728)